### PR TITLE
Fix Imports for Timer module

### DIFF
--- a/src/Util/Timer.lua
+++ b/src/Util/Timer.lua
@@ -24,7 +24,6 @@
 --]]
 
 
--- local Knit = require(game:GetService("ReplicatedStorage").Knit)
 local Signal = require(script.Parent.Signal)
 
 local RunService = game:GetService("RunService")

--- a/src/Util/Timer.lua
+++ b/src/Util/Timer.lua
@@ -24,8 +24,8 @@
 --]]
 
 
-local Knit = require(game:GetService("ReplicatedStorage").Knit)
-local Signal = require(Knit.Util.Signal)
+-- local Knit = require(game:GetService("ReplicatedStorage").Knit)
+local Signal = require(script.Parent.Signal)
 
 local RunService = game:GetService("RunService")
 


### PR DESCRIPTION
The signal import requires Knit then uses `Knit.Util.Signal` to import the module,
this causes a runtime error in Roblox-TS as Knit isn't a parent of ReplicatedStorage,
instead its a descendant.

I've tested it and I get no initial errors on the require. This comes down to personal preference though.