### PR TITLE
Fix race conditions for Knit

### DIFF
--- a/src/KnitClient.lua
+++ b/src/KnitClient.lua
@@ -30,10 +30,10 @@ type Service = {
 
 local KnitClient = {}
 
-KnitClient.Version = script.Parent.Version.Value
+KnitClient.Version = script.Parent:WaitForChild("Version").Value
 KnitClient.Player = game:GetService("Players").LocalPlayer
 KnitClient.Controllers = {} :: {[string]: Controller}
-KnitClient.Util = script.Parent.Util
+KnitClient.Util = script.Parent:WaitForChild("Util")
 
 local Promise = require(KnitClient.Util.Promise)
 local Loader = require(KnitClient.Util.Loader)

--- a/src/KnitServer.lua
+++ b/src/KnitServer.lua
@@ -36,9 +36,9 @@ type ServiceClient = {
 
 local KnitServer = {}
 
-KnitServer.Version = script.Parent:WaitForChild("Version").Value
+KnitServer.Version = script.Parent.Version.Value
 KnitServer.Services = {} :: {[string]: Service}
-KnitServer.Util = script.Parent:WaitForChild("Util")
+KnitServer.Util = script.Parent.Util
 
 
 local knitRepServiceFolder = Instance.new("Folder")

--- a/src/KnitServer.lua
+++ b/src/KnitServer.lua
@@ -36,9 +36,9 @@ type ServiceClient = {
 
 local KnitServer = {}
 
-KnitServer.Version = script.Parent.Version.Value
+KnitServer.Version = script.Parent:WaitForChild("Version").Value
 KnitServer.Services = {} :: {[string]: Service}
-KnitServer.Util = script.Parent.Util
+KnitServer.Util = script.Parent:WaitForChild("Util")
 
 
 local knitRepServiceFolder = Instance.new("Folder")


### PR DESCRIPTION
Knit does not always have the Util folder or the Version object loaded when it tries to reference it, leading to some issues caused by the race condition:
![image](https://user-images.githubusercontent.com/32179912/128739517-3d629583-0029-4890-b521-31985bf3eeff.png)

This pull request adds :WaitForChild statements to ensure that Knit doesn't fail to start at no fault to the developer using it.
