### PR TITLE
Fixed timer exhausting allowed execution time

### DIFF
--- a/src/Util/Timer.lua
+++ b/src/Util/Timer.lua
@@ -35,7 +35,6 @@ Timer.__index = Timer
 
 function Timer.new(interval: number, janitor)
 	assert(type(interval) == "number", "Argument #1 to Timer.new must be a number; got " .. type(interval))
-	assert(interval > 0, "Argument #1 to Timer.new must be greater than 0; got " .. tostring(interval))
 	local self = setmetatable({}, Timer)
 	self._runHandle = nil
 	self.Interval = interval
@@ -56,12 +55,12 @@ function Timer:Start()
 	if self._runHandle then return end
 	local n = 1
 	local start = time()
-	local nextTick = start + self.Interval
-	self._runHandle = RunService.Heartbeat:Connect(function()
+	local nextTick = start + (self.Interval == 0 and 1/60 or self.Interval)
+	self._runHandle = RunService.Heartbeat:Connect(function(step)
 		local now = time()
 		while now >= nextTick do
 			n += 1
-			nextTick = start + (self.Interval * n)
+			nextTick = start + ((self.Interval == 0 and step or self.Interval) * n)
 			self.Tick:Fire()
 		end
 	end)


### PR DESCRIPTION
Allowing the timer to tick once every frame step. The use case is scripts that require the utilization of varying timer intervals which could be 0. This defeats the need for additional checks and allows people to make timers that tick each frame or stop after the next frame.