### PR TITLE
Fix issues in Component with more than 1 RequiredComponent

### DIFF
--- a/src/Util/Component.lua
+++ b/src/Util/Component.lua
@@ -273,6 +273,8 @@ function Component.new(tag, class, renderPriority, requireComponents)
 		end
 		for _,requiredComponent in ipairs(self._requireComponents) do
 			tagsReady[requiredComponent] = false
+		end
+		for _,requiredComponent in ipairs(self._requireComponents) do
 			self._janitor:Add(Component.ObserveFromTag(requiredComponent, function(_component, janitor)
 				tagsReady[requiredComponent] = true
 				Check()


### PR DESCRIPTION
I introduced a bug (see #139) when trying to remove a redundant loop. The bug introduced would allow for errors to occur whenever the component was observed immediately. This was not caught before due to the use of the Thread library, which has been replaced by the roblox task library. I considered using the `task.defer` method which would work, but using two loops is probably a more future-proof way to fix the issue.