### PR TITLE
Update Streamable.lua

### DIFF
--- a/src/Util/Streamable.lua
+++ b/src/Util/Streamable.lua
@@ -85,9 +85,7 @@ function Streamable:Destroy()
 end
 
 
-local s = Streamable.new(workspace, "X")
-export type Streamable = typeof(s)
-s:Destroy()
+export type Streamable = typeof(Streamable.new(workspace, "X"))
 
 
 return Streamable


### PR DESCRIPTION
`export type x = typeof(x.new())` doesn't actually call `x.new()`, this is tested using:

```lua
local Object = {}
Object.__index = Object

function Object.new()
	print("Object.new")
	return setmetatable({}, Object)
end

export type Object = typeof(Object.new())
return Object
```